### PR TITLE
Add health and src data endpoints

### DIFF
--- a/generate-infos.js
+++ b/generate-infos.js
@@ -1,5 +1,5 @@
 const {exec} = require('child_process')
-const {readFile, writeFile} = require('fs/promises')
+const {readFile, writeFile} = require('fs').promises
 
 function run(cmd) {
   return new Promise((resolve, reject) => {

--- a/generate-infos.js
+++ b/generate-infos.js
@@ -1,0 +1,37 @@
+const {exec} = require('child_process')
+const {readFile, writeFile} = require('fs/promises')
+
+function run(cmd) {
+  return new Promise((resolve, reject) => {
+    exec(cmd, (error, stdout, stderr) => {
+      if (error) {
+        return reject(error)
+      }
+
+      if (stderr) {
+        return reject(stderr)
+      }
+
+      resolve(stdout)
+    })
+  })
+}
+
+// Usage example
+(async () => {
+  let gitCurrentHash = await run('git rev-parse HEAD')
+  gitCurrentHash = gitCurrentHash.replace(/(\r\n|\n|\r)/gm, '')
+  console.log(gitCurrentHash)
+  const data = JSON.parse(await readFile('package.json', 'utf8'))
+  const packageNameDecoupageAdmin = '@etalab/decoupage-administratif'
+  const decoupageAdminPackageVersion = data.devDependencies[packageNameDecoupageAdmin]
+  const packageNameApiGeo = data.name
+  const apiGeoPackageVersion = data.version
+  console.log(decoupageAdminPackageVersion)
+  await writeFile('api_infos.json', JSON.stringify({
+    // eslint-disable-next-line camelcase
+    git_hash_api_geo: gitCurrentHash,
+    [packageNameApiGeo]: apiGeoPackageVersion,
+    [packageNameDecoupageAdmin]: decoupageAdminPackageVersion
+  }))
+})()

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
       "unicorn/filename-case": "off",
       "import/order": "off",
       "no-return-assign": "off",
-      "ava/no-import-test-files": "off"
+      "ava/no-import-test-files": "off",
+      "import/extensions": "off"
     },
     "ignores": "test/*.js"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "test": "NODE_OPTIONS=--max_old_space_size=2048 nyc mocha --exit --timeout 5000",
     "download-sources": "./download-sources.sh",
     "build-only": "node --max_old_space_size=4096 build",
-    "build": "yarn download-sources && yarn build-only"
+    "build": "yarn download-sources && yarn build-only",
+    "generate-api-infos": "node generate-infos.js"
   },
   "xo": {
     "semicolon": false,

--- a/server.js
+++ b/server.js
@@ -24,10 +24,10 @@ if (process.env.NODE_ENV !== 'production') {
   app.use(morgan('dev'))
 }
 
-const api_info_filename = 'api_infos.json'
-let api_infos = {}
-if (fs.existsSync(api_info_filename)) {
-  api_infos = JSON.parse(fs.readFileSync(api_info_filename))
+const apiInfoFilename = 'api_infos.json'
+let apiInfos = {}
+if (fs.existsSync(apiInfoFilename)) {
+  apiInfos = JSON.parse(fs.readFileSync(apiInfoFilename))
 }
 
 if (process.env.SENTRY_DSN) {
@@ -342,9 +342,9 @@ app.get('/healthcheck', (req, res) => {
   }
 })
 
- app.get('/infos', (req, res) => {
+app.get('/infos', (req, res) => {
   try {
-    res.send(api_infos)
+    res.send(apiInfos)
   } catch (error) {
     res.status(503).send()
   }

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const express = require('express')
 const cors = require('cors')
 const morgan = require('morgan')
@@ -21,6 +22,12 @@ app.use(cors({origin: true}))
 
 if (process.env.NODE_ENV !== 'production') {
   app.use(morgan('dev'))
+}
+
+const api_info_filename = 'api_infos.json'
+let api_infos = {}
+if (fs.existsSync(api_info_filename)) {
+  api_infos = JSON.parse(fs.readFileSync(api_info_filename))
 }
 
 if (process.env.SENTRY_DSN) {
@@ -331,6 +338,14 @@ app.get('/healthcheck', (req, res) => {
     res.send(healthcheck)
   } catch (error) {
     healthcheck.message = error
+    res.status(503).send()
+  }
+})
+
+ app.get('/infos', (req, res) => {
+  try {
+    res.send(api_infos)
+  } catch (error) {
     res.status(503).send()
   }
 })

--- a/server.js
+++ b/server.js
@@ -319,6 +319,22 @@ app.get('/raw/regions.json', (req, res) => {
   res.download('data/regions.json')
 })
 
+app.get('/healthcheck', (req, res) => {
+  const hrtimeIntAsString = String(process.hrtime.bigint())
+  const healthcheck = {
+    uptime: process.uptime(),
+    responsetime: hrtimeIntAsString,
+    message: 'OK',
+    timestamp: Date.now()
+  }
+  try {
+    res.send(healthcheck)
+  } catch (error) {
+    healthcheck.message = error
+    res.status(503).send()
+  }
+})
+
 /* Definition */
 app.get('/definition.yml', (req, res) => {
   res.sendFile(__dirname + '/definition.yml')


### PR DESCRIPTION
Add

- a new `/healthcheck` endpoint
- an /infos endpoint about the version of the deployed code git hash, the API Geo version and the dependency `@etalab/decoupage-administratif` version