### PR TITLE
Update code to manage exact result as first result when existing

### DIFF
--- a/lib/searchableCollection/indexes/text.js
+++ b/lib/searchableCollection/indexes/text.js
@@ -35,6 +35,7 @@ class TextIndex {
 
   find(terms, options = {}) {
     let boosted = false
+    let exactResults
     const results = this._index.search(terms)
       .map(result => {
         const item = clone(this._refIndex.get(result.ref))
@@ -47,7 +48,12 @@ class TextIndex {
 
         return item
       })
-    return boosted ? sortBy(results, c => -c._score) : results
+    const filtered = results.filter(item => normalizeString(item.nom) === terms)
+    if (filtered.length > 0) {
+      exactResults = [...filtered, ...results.filter(item => normalizeString(item.nom) !== terms)]
+    }
+
+    return boosted ? sortBy(results, c => -c._score) : (exactResults ? exactResults : results)
   }
 }
 


### PR DESCRIPTION
Return exact match(es) first when no boost e.g by population as scoring algorithm does not rank more exact matches than other case e.g scoring for search "mont" is not higher than the one with montagne a subset of mont.
PR only work for single name and is untested with compound cities names like something like `Aix-Les-Bains`as we would need to manage multiples terms and separators in this case.

The other options to maybe adopt later on will be to upgrade Lunr to 2.X version. It may causes other issues due to some changes https://lunrjs.com/guides/searching.html