### PR TITLE
Update swagger definition.yml due to user feedback

### DIFF
--- a/definition.yml
+++ b/definition.yml
@@ -444,7 +444,7 @@ paths:
         - $ref: '#/parameters/epciGeometryParam'
       responses:
         '200':
-          description: Informations concernant une commune
+          description: Informations concernant un EPCI
           schema:
             $ref: '#/definitions/Epci'
         400:
@@ -705,7 +705,7 @@ definitions:
         $ref: '#/definitions/Region'
       associees:
         type: array
-        description: Liste des codes postaux associés à la commune
+        description: Liste des codes INSEE des communes associées de la commune, si présentes
         items:
           type: object
           properties:
@@ -715,7 +715,7 @@ definitions:
               type: string
       deleguees:
         type: array
-        description: Liste des codes postaux associés à la commune
+        description: Liste des codes INSEE des communes déléguées de la commune, si présentes
         items:
           type: object
           properties:


### PR DESCRIPTION
See https://www.data.gouv.fr/dataservices/api-decoupage-administratif-api-geo/discussions/?discussion_id=688bcc69edcd41e8c86b27b0

One is a pure copy/paste error, the other about `associees` and `deleguees` is not empty and is available contrary to the suggestion from feedback but the descriptions for both are "wrong". Fixed

Possible to test with 

```bash
curl -s 'https://geo.api.gouv.fr/communes?fields=code,nom,surface,departement,zone,population,deleguees,associees' | jq -c -r .[] | grep -v '"associees":null'
```

```bash
curl -s 'https://geo.api.gouv.fr/communes?fields=code,nom,surface,departement,zone,population,deleguees,associees' | jq -c -r .[] | grep -v '"deleguees":null'
```