### PR TITLE
Fix broken links due to cleaning to use Minio

### DIFF
--- a/download-sources.sh
+++ b/download-sources.sh
@@ -4,13 +4,13 @@ COMMUNES_ASSOCIEES_DELEGUEES=${COMMUNES_ASSOCIEES_DELEGUEES:-NO}
 echo "Create data directory"
 mkdir -p data
 echo "Retrieve datasets"
-wget -N -P data/ https://files.data.gouv.fr/dinum-datasets-geo/contours-administratifs/${YEAR}/geojson/communes-5m.geojson.gz
-wget -N -P data/ https://files.data.gouv.fr/dinum-datasets-geo/contours-administratifs/${YEAR}/geojson/communes-50m.geojson.gz
+wget -N -P data/ https://object.data.gouv.fr/contours-administratifs/${YEAR}/geojson/communes-5m.geojson.gz
+wget -N -P data/ https://object.data.gouv.fr/contours-administratifs/${YEAR}/geojson/communes-50m.geojson.gz
 if [ "$COMMUNES_ASSOCIEES_DELEGUEES" != "NO" ]; then
-    wget -N -P data/ https://files.data.gouv.fr/dinum-datasets-geo/contours-administratifs/${YEAR}/geojson/communes-associees-deleguees-5m.geojson.gz
-    wget -N -P data/ https://files.data.gouv.fr/dinum-datasets-geo/contours-administratifs/${YEAR}/geojson/communes-associees-deleguees-50m.geojson.gz
+    wget -N -P data/ https://object.data.gouv.fr/contours-administratifs/${YEAR}/geojson/communes-associees-deleguees-5m.geojson.gz
+    wget -N -P data/ https://object.data.gouv.fr/contours-administratifs/${YEAR}/geojson/communes-associees-deleguees-50m.geojson.gz
 fi
-wget -N -P data/ https://files.data.gouv.fr/dinum-datasets-geo/contours-administratifs/${YEAR}/geojson/mairies.geojson.gz
-wget -N -P data/ https://files.data.gouv.fr/dinum-datasets-geo/contours-administratifs/${YEAR}/geojson/epci-5m.geojson.gz
-wget -N -P data/ https://files.data.gouv.fr/dinum-datasets-geo/contours-administratifs/${YEAR}/geojson/epci-50m.geojson.gz
+wget -N -P data/ https://object.data.gouv.fr/contours-administratifs/${YEAR}/geojson/mairies.geojson.gz
+wget -N -P data/ https://object.data.gouv.fr/contours-administratifs/${YEAR}/geojson/epci-5m.geojson.gz
+wget -N -P data/ https://object.data.gouv.fr/contours-administratifs/${YEAR}/geojson/epci-50m.geojson.gz
 echo "Completed"


### PR DESCRIPTION
Directory not available due to files.data.gouv.fr decommission https://files.data.gouv.fr/dinum-datasets-geo/contours-administratifs/ to use instead Minio https://object.data.gouv.fr/contours-administratifs/

Directory browsing can be done via https://object.infra.data.gouv.fr/browser/contours-administratifs/
 